### PR TITLE
More robust `external_ips` metric

### DIFF
--- a/lib/version.py
+++ b/lib/version.py
@@ -1,1 +1,1 @@
-__version__ = '3.1.3'
+__version__ = '3.1.4-alpha0'


### PR DESCRIPTION
## Description

In some cases the metric `external_ips` is not returned as a list of strings. This pull request makes the metric more robust to ensure the response includes a list with strings. In case it truly is not possible due to an unknown type, logging is created so the issue can be further debugged. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test using an alpha version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
